### PR TITLE
feat: Texture2DにUV座標を追加

### DIFF
--- a/Promete.Example/examples/graphics/sprite_sheet.cs
+++ b/Promete.Example/examples/graphics/sprite_sheet.cs
@@ -1,0 +1,37 @@
+﻿using Promete.Example.Kernel;
+using Promete.Graphics;
+using Promete.Input;
+using Promete.Nodes;
+
+namespace Promete.Example.examples.graphics;
+
+[Demo("/graphics/sprite_sheet.demo", "Sprite Sheet Test")]
+public class sprite_sheet : Scene
+{
+    private readonly Keyboard _keyboard;
+    private Texture2D[] _textures;
+
+    public sprite_sheet(Keyboard keyboard)
+    {
+        _keyboard = keyboard;
+        _textures = Window.TextureFactory.LoadSpriteSheet("assets/icons.png", 3, 1, (32, 32));
+        for (int i = 0; i < _textures.Length; i++)
+        {
+            var sprite = new Sprite(_textures[i])
+                .Location(64 * i + 16, 16)
+                .Scale(2, 2);
+            Root.Add(sprite);
+        }
+    }
+
+    public override void OnUpdate()
+    {
+        if (_keyboard.Escape.IsKeyUp)
+            App.LoadScene<MainScene>();
+    }
+
+    public override void OnDestroy()
+    {
+        _textures[0].Dispose();
+    }
+}

--- a/Promete/CHANGELOG.md
+++ b/Promete/CHANGELOG.md
@@ -1,4 +1,4 @@
-﻿## 1.3.2
+## 1.3.2
 - fix(Node): Sizeプロパティを変更しても内部のジオメトリマトリックスが変化しない問題を修正
 - fix(OpenGLDesktopWindow): TakeScreenshotAsImage()の戻り値を修正し、警告を抑制
 - fix(Rect, RectInt): Centerプロパティを追加し、矩形の中心座標を取得できるように

--- a/Promete/Graphics/FrameBuffer.cs
+++ b/Promete/Graphics/FrameBuffer.cs
@@ -1,9 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.Drawing;
-using Promete.Internal;
 using Promete.Nodes;
 
 namespace Promete.Graphics;

--- a/Promete/Graphics/Texture2D.cs
+++ b/Promete/Graphics/Texture2D.cs
@@ -18,13 +18,30 @@ public readonly struct Texture2D : IDisposable
     /// </summary>
     public VectorInt Size { get; }
 
+    /// <summary>
+    /// このテクスチャの左上のUV座標を取得します。
+    /// </summary>
+    public Vector UvStart { get; }
+
+    /// <summary>
+    /// このテクスチャの右下のUV座標を取得します。
+    /// </summary>
+    public Vector UvEnd { get; }
+
     private readonly Action<Texture2D> _onDispose;
 
     internal Texture2D(int handle, VectorInt size, Action<Texture2D> onDispose)
+        : this(handle, size, onDispose, (0, 0), (1, 1))
+    {
+    }
+
+    internal Texture2D(int handle, VectorInt size, Action<Texture2D> onDispose, Vector uvStart, Vector uvEnd)
     {
         Handle = handle;
         Size = size;
         _onDispose = onDispose;
+        UvStart = uvStart;
+        UvEnd = uvEnd;
     }
 
     /// <summary>

--- a/Promete/Nodes/Renderer/GL/Helper/GLBatchTextureRenderer.cs
+++ b/Promete/Nodes/Renderer/GL/Helper/GLBatchTextureRenderer.cs
@@ -16,8 +16,8 @@ public class GLBatchTextureRenderer : IDisposable
 {
     private const int InitialInstanceCapacity = 512;
 
-    // per-instance: mat4(16) + vec4 tintColor(4) = 20 floats
-    private const int InstanceStride = 20;
+    // per-instance: mat4(16) + vec4 tintColor(4) + vec4 uvRect(4) = 24 floats
+    private const int InstanceStride = 24;
 
     private readonly OpenGLDesktopWindow _window;
     private bool _initialized;
@@ -97,6 +97,14 @@ public class GLBatchTextureRenderer : IDisposable
             _instanceData[offset + 17] = c.G / 255f;
             _instanceData[offset + 18] = c.B / 255f;
             _instanceData[offset + 19] = c.A / 255f;
+
+            // UV座標（シェーダー側でmix補間するため、Y反転は不要）
+            var uvStart = cmd.Texture.UvStart;
+            var uvEnd = cmd.Texture.UvEnd;
+            _instanceData[offset + 20] = uvStart.X;
+            _instanceData[offset + 21] = uvStart.Y;
+            _instanceData[offset + 22] = uvEnd.X;
+            _instanceData[offset + 23] = uvEnd.Y;
         }
 
         // インスタンスデータをGPUに転送
@@ -196,6 +204,12 @@ public class GLBatchTextureRenderer : IDisposable
             (uint)(InstanceStride * sizeof(float)), 16 * sizeof(float));
         gl.EnableVertexAttribArray(6);
         gl.VertexAttribDivisor(6, 1);
+
+        // UvRect (location 7): xy = uvStart, zw = uvEnd
+        gl.VertexAttribPointer(7, 4, VertexAttribPointerType.Float, false,
+            (uint)(InstanceStride * sizeof(float)), 20 * sizeof(float));
+        gl.EnableVertexAttribArray(7);
+        gl.VertexAttribDivisor(7, 1);
 
         gl.BindBuffer(BufferTargetARB.ArrayBuffer, 0);
         gl.BindVertexArray(0);

--- a/Promete/Nodes/Renderer/GL/Helper/GLTextureRendererHelper.cs
+++ b/Promete/Nodes/Renderer/GL/Helper/GLTextureRendererHelper.cs
@@ -59,28 +59,16 @@ public class GLTextureRendererHelper
         gl.DeleteShader(vsh);
         gl.DeleteShader(fsh);
 
-        // スプライトは基本のポリゴンが四角形に決まっているので、あらかじめ頂点情報を用意しておく
-        Span<float> vertices =
-        [
-            1.0f, 0.0f, 1.0f, 0.0f, // 右下
-            1.0f, 1.0f, 1.0f, 1.0f, // 右上
-            0.0f, 1.0f, 0.0f, 1.0f, // 左上
-            0.0f, 0.0f, 0.0f, 0.0f // 左下
-        ];
-
-        // バッファに頂点情報を書き込む
+        // VBO初期化（空データで確保）
         _vao = gl.GenVertexArray();
         gl.BindVertexArray(_vao);
         _vbo = gl.GenBuffer();
         gl.BindBuffer(BufferTargetARB.ArrayBuffer, _vbo);
-        gl.BufferData<float>(BufferTargetARB.ArrayBuffer, vertices, BufferUsageARB.StaticDraw);
+        gl.BufferData(BufferTargetARB.ArrayBuffer, 16 * sizeof(float), (nint)0, BufferUsageARB.DynamicDraw); // 4頂点×4float
 
-        // 4つのfloat値のうち、最初の2つを頂点の座標として登録する
+        // 頂点属性設定（座標・UV）
         gl.VertexAttribPointer(0, 2, VertexAttribPointerType.Float, false, 4 * sizeof(float), 0);
         gl.EnableVertexAttribArray(0);
-
-        // 4つのfloat値のうち、次の2つをテクスチャ座標として登録する
-        // テクスチャ座標属性
         gl.VertexAttribPointer(1, 2, VertexAttribPointerType.Float, false, 4 * sizeof(float), 2 * sizeof(float));
         gl.EnableVertexAttribArray(1);
 
@@ -118,6 +106,30 @@ public class GLTextureRendererHelper
         var c = color ?? Color.White;
         var finalWidth = overriddenWidth ?? node.Size.X;
         var finalHeight = overriddenHeight ?? node.Size.Y;
+
+        // Texture2DのUV座標を取得
+        var uvStart = texture.UvStart;
+        var uvEnd = texture.UvEnd;
+        // OpenGLのUV座標はY軸が反転しているため、調整
+        uvStart.Y = 1 - uvStart.Y;
+        uvEnd.Y = 1 - uvEnd.Y;
+
+        // 頂点データ（座標＋UV）を構築
+        Span<float> vertices =
+        [
+            // 右下
+            1.0f, 0.0f, uvEnd.X, uvEnd.Y,
+            // 右上
+            1.0f, 1.0f, uvEnd.X, uvStart.Y,
+            // 左上
+            0.0f, 1.0f, uvStart.X, uvStart.Y,
+            // 左下
+            0.0f, 0.0f, uvStart.X, uvEnd.Y
+        ];
+
+        // VBOへ頂点データを書き込み
+        gl.BindBuffer(BufferTargetARB.ArrayBuffer, _vbo);
+        gl.BufferSubData<float>(BufferTargetARB.ArrayBuffer, 0, vertices);
 
         // モデル行列を計算
         var modelMatrix =

--- a/Promete/Nodes/Renderer/GL/Helper/GLTextureRendererHelper.cs
+++ b/Promete/Nodes/Renderer/GL/Helper/GLTextureRendererHelper.cs
@@ -110,9 +110,9 @@ public class GLTextureRendererHelper
         // Texture2DのUV座標を取得
         var uvStart = texture.UvStart;
         var uvEnd = texture.UvEnd;
-        // OpenGLのUV座標はY軸が反転しているため、調整
-        uvStart.Y = 1 - uvStart.Y;
-        uvEnd.Y = 1 - uvEnd.Y;
+
+        // UV座標のY軸を反転する（OpenGLではY軸が下向き）
+        (uvStart.Y, uvEnd.Y) = (uvEnd.Y, uvStart.Y);
 
         // 頂点データ（座標＋UV）を構築
         Span<float> vertices =

--- a/Promete/Resources/shaders/texture_instanced.vert
+++ b/Promete/Resources/shaders/texture_instanced.vert
@@ -6,6 +6,7 @@ layout(location = 3) in vec4 iModel1;
 layout(location = 4) in vec4 iModel2;
 layout(location = 5) in vec4 iModel3;
 layout(location = 6) in vec4 iTintColor;
+layout(location = 7) in vec4 iUvRect; // xy = uvStart, zw = uvEnd
 
 out vec2 fUv;
 out vec4 fTintColor;
@@ -16,6 +17,6 @@ void main()
 {
     mat4 model = mat4(iModel0, iModel1, iModel2, iModel3);
     gl_Position = uProjection * model * vec4(vPos, 0.0, 1.0);
-    fUv = vUv;
+    fUv = mix(iUvRect.xy, iUvRect.zw, vUv);
     fTintColor = iTintColor;
 }

--- a/Promete/Windowing/GLDesktop/OpenGLTextureFactory.cs
+++ b/Promete/Windowing/GLDesktop/OpenGLTextureFactory.cs
@@ -79,9 +79,37 @@ public class OpenGLTextureFactory(GL gl, PrometeApp app) : TextureFactory
 
     private Texture2D[] LoadSpriteSheet(Image bmp, int horizontalCount, int verticalCount, VectorInt size)
     {
-        using (bmp)
-        using (var img = bmp.CloneAs<Rgba32>())
+        var width = (float)bmp.Width;
+        var height = (float)bmp.Height;
+        var handle = LoadFromImageSharpImage(bmp).Handle;
+
+        var textures = new Texture2D[verticalCount * horizontalCount];
+        for (var y = 0; y < verticalCount; y++)
         {
+            for (var x = 0; x < horizontalCount; x++)
+            {
+                var px = x * size.X;
+                var py = y * size.Y;
+
+                if (px + size.X > width) throw new ArgumentException(null, nameof(horizontalCount));
+                if (py + size.Y > height) throw new ArgumentException(null, nameof(verticalCount));
+
+                var uvStart = new Vector(px / width, py / height);
+                var uvEnd = new Vector((px + size.X - 1) / width, (py + size.Y - 1) / height);
+
+                textures[y * horizontalCount + x] = new Texture2D(handle, size, DisposeTexture, uvStart, uvEnd);
+            }
+        }
+
+        bmp.Dispose();
+        return textures;
+    }
+
+    private Texture2D[] LoadSpriteSheetLegacy(Image bmp, int horizontalCount, int verticalCount, VectorInt size)
+    {
+        using (bmp)
+        {
+            using var img = bmp.CloneAs<Rgba32>();
             var textures = new Texture2D[verticalCount * horizontalCount];
 
             for (var y = 0; y < verticalCount; y++)

--- a/Promete/Windowing/GLDesktop/OpenGLTextureFactory.cs
+++ b/Promete/Windowing/GLDesktop/OpenGLTextureFactory.cs
@@ -95,7 +95,7 @@ public class OpenGLTextureFactory(GL gl, PrometeApp app) : TextureFactory
                 if (py + size.Y > height) throw new ArgumentException(null, nameof(verticalCount));
 
                 var uvStart = new Vector(px / width, py / height);
-                var uvEnd = new Vector((px + size.X - 1) / width, (py + size.Y - 1) / height);
+                var uvEnd = new Vector((px + size.X) / width, (py + size.Y) / height);
 
                 textures[y * horizontalCount + x] = new Texture2D(handle, size, DisposeTexture, uvStart, uvEnd);
             }


### PR DESCRIPTION
fix #52

* Texture2Dに `UvStart `UvEnd` プロパティを追加
* OpenGLのテクスチャレンダラーが、 `UvStart` `UvEnd` プロパティを用いるよう変更
* OpenGLのテクスチャファクトリの `LoadSpriteSheet` が、本機能を用いて1つだけハンドルを生成し、複数のTexture2Dで使い回すように