### PR TITLE
feat: ShaderProgram/Material APIとエフェクトデモの追加

### DIFF
--- a/Promete.Example/examples/graphics/materialEffect.cs
+++ b/Promete.Example/examples/graphics/materialEffect.cs
@@ -1,0 +1,238 @@
+using System.Drawing;
+using System.Numerics;
+using Promete.Example.Kernel;
+using Promete.Graphics;
+using Promete.Graphics.Fonts;
+using Promete.Input;
+using Promete.Nodes;
+
+namespace Promete.Example.examples.graphics;
+
+/// <summary>
+/// Material とカスタムシェーダーによる画像エフェクトのデモ。
+/// セピア・グレースケール・モザイク・縁取り（白1px）・ラスタースクロールの5種類を表示します。
+/// </summary>
+[Demo("/graphics/materialEffect.demo", "Materialとカスタムシェーダーによる画像エフェクトの例")]
+public class MaterialEffectDemo(ConsoleLayer console, Keyboard keyboard) : Scene
+{
+    private Texture2D _texture;
+    private ShaderProgram _sepiaShader = null!;
+    private ShaderProgram _grayscaleShader = null!;
+    private ShaderProgram _mosaicShader = null!;
+    private ShaderProgram _outlineShader = null!;
+    private ShaderProgram _rasterScrollShader = null!;
+    private Material _rasterScrollMat = null!;
+
+    // バッチドレンダラーのVAOレイアウトに合わせた頂点シェーダー
+    private const string VertSrc = """
+        #version 330 core
+        layout(location = 0) in vec2 vPos;
+        layout(location = 1) in vec2 vUv;
+        layout(location = 2) in vec4 iModel0;
+        layout(location = 3) in vec4 iModel1;
+        layout(location = 4) in vec4 iModel2;
+        layout(location = 5) in vec4 iModel3;
+        layout(location = 6) in vec4 iTintColor;
+        layout(location = 7) in vec4 iUvRect;
+
+        out vec2 fUv;
+        out vec4 fTintColor;
+
+        uniform mat4 uProjection;
+
+        void main()
+        {
+            mat4 model = mat4(iModel0, iModel1, iModel2, iModel3);
+            gl_Position = uProjection * model * vec4(vPos, 0.0, 1.0);
+            fUv = mix(iUvRect.xy, iUvRect.zw, vUv);
+            fTintColor = iTintColor;
+        }
+        """;
+
+    // セピア変換
+    private const string SepiaFragSrc = """
+        #version 330 core
+        in vec2 fUv;
+        in vec4 fTintColor;
+        uniform sampler2D uTexture0;
+        out vec4 FragColor;
+
+        void main()
+        {
+            vec4 c = texture(uTexture0, fUv) * fTintColor;
+            float r = dot(c.rgb, vec3(0.393, 0.769, 0.189));
+            float g = dot(c.rgb, vec3(0.349, 0.686, 0.168));
+            float b = dot(c.rgb, vec3(0.272, 0.534, 0.131));
+            FragColor = vec4(r, g, b, c.a);
+        }
+        """;
+
+    // グレースケール変換（輝度係数: BT.601）
+    private const string GrayscaleFragSrc = """
+        #version 330 core
+        in vec2 fUv;
+        in vec4 fTintColor;
+        uniform sampler2D uTexture0;
+        out vec4 FragColor;
+
+        void main()
+        {
+            vec4 c = texture(uTexture0, fUv) * fTintColor;
+            float gray = dot(c.rgb, vec3(0.299, 0.587, 0.114));
+            FragColor = vec4(gray, gray, gray, c.a);
+        }
+        """;
+
+    // モザイク（uBlockSize px 単位でスナップ）
+    private const string MosaicFragSrc = """
+        #version 330 core
+        in vec2 fUv;
+        in vec4 fTintColor;
+        uniform sampler2D uTexture0;
+        uniform vec2 uTextureSize;
+        uniform float uBlockSize;
+        out vec4 FragColor;
+
+        void main()
+        {
+            vec2 pixel   = fUv * uTextureSize;
+            vec2 snapped = floor(pixel / uBlockSize) * uBlockSize + uBlockSize * 0.5;
+            vec2 uv      = snapped / uTextureSize;
+            FragColor = texture(uTexture0, uv) * fTintColor;
+        }
+        """;
+
+    // ラスタースクロール: 走査線ごとに sin でX方向オフセット → うにょうにょ
+    private const string RasterScrollFragSrc = """
+        #version 330 core
+        in vec2 fUv;
+        in vec4 fTintColor;
+        uniform sampler2D uTexture0;
+        uniform float uTime;
+        out vec4 FragColor;
+
+        void main()
+        {
+            // 走査線（Y座標）ごとにサイン波でX方向へオフセット
+            float offset = sin(fUv.y * 18.0 + uTime * 4.0) * 0.06;
+            vec2 uv = vec2(fUv.x + offset, fUv.y);
+            FragColor = texture(uTexture0, uv) * fTintColor;
+        }
+        """;
+
+    // 1px縁取り（白）: 透明ピクセルの隣に不透明ピクセルがあれば白を描画
+    private const string OutlineFragSrc = """
+        #version 330 core
+        in vec2 fUv;
+        in vec4 fTintColor;
+        uniform sampler2D uTexture0;
+        uniform vec2 uTextureSize;
+        out vec4 FragColor;
+
+        void main()
+        {
+            vec4 c = texture(uTexture0, fUv) * fTintColor;
+            if (c.a > 0.5) {
+                FragColor = c;
+                return;
+            }
+            vec2 texel = 1.0 / uTextureSize;
+            float n = texture(uTexture0, fUv + vec2( 0.0,      texel.y)).a;
+            float s = texture(uTexture0, fUv + vec2( 0.0,     -texel.y)).a;
+            float e = texture(uTexture0, fUv + vec2( texel.x,  0.0    )).a;
+            float w = texture(uTexture0, fUv + vec2(-texel.x,  0.0    )).a;
+            FragColor = (n + s + e + w > 0.5)
+                ? vec4(1.0, 1.0, 1.0, 1.0)
+                : vec4(0.0);
+        }
+        """;
+
+    public override void OnStart()
+    {
+        console.Print("Press [ESC] to exit");
+
+        _texture = Window.TextureFactory.Load("assets/ichigo.png");
+
+        // シェーダーのコンパイル（OnStart以降・メインスレッドで呼ぶ必要あり）
+        _sepiaShader        = ShaderProgram.Create().Vertex(VertSrc).Fragment(SepiaFragSrc).Compile();
+        _grayscaleShader    = ShaderProgram.Create().Vertex(VertSrc).Fragment(GrayscaleFragSrc).Compile();
+        _mosaicShader       = ShaderProgram.Create().Vertex(VertSrc).Fragment(MosaicFragSrc).Compile();
+        _outlineShader      = ShaderProgram.Create().Vertex(VertSrc).Fragment(OutlineFragSrc).Compile();
+        _rasterScrollShader = ShaderProgram.Create().Vertex(VertSrc).Fragment(RasterScrollFragSrc).Compile();
+
+        var texSize = new Vector2(_texture.Size.X, _texture.Size.Y);
+
+        // マテリアルの作成とUniform設定
+        var sepiaMat     = new Material(_sepiaShader);
+
+        var grayscaleMat = new Material(_grayscaleShader);
+
+        var mosaicMat    = new Material(_mosaicShader);
+        mosaicMat["uTextureSize"] = texSize;
+        mosaicMat["uBlockSize"]   = 4.0f;
+
+        var outlineMat   = new Material(_outlineShader);
+        outlineMat["uTextureSize"] = texSize;
+
+        _rasterScrollMat = new Material(_rasterScrollShader);
+        _rasterScrollMat["uTime"] = 0.0f;
+
+        // 2×3グリッドで6エフェクトを配置
+        var font      = Font.GetDefault(18);
+        var dispSize  = 180;
+        var scale     = (float)dispSize / _texture.Size.X;
+        var cols      = 3;
+        var marginX   = (Window.Width  - cols * dispSize) / (cols + 1);
+        var marginY   = 60;
+        var labelH    = 28;
+        var rowH      = dispSize + labelH + marginY;
+
+        (string Label, Material? Mat)[] effects =
+        [
+            ("デフォルト",           null),
+            ("セピア",               sepiaMat),
+            ("グレースケール",        grayscaleMat),
+            ("モザイク",              mosaicMat),
+            ("縁取り（白 1px）",     outlineMat),
+            ("ラスタースクロール",    _rasterScrollMat),
+        ];
+
+        for (var i = 0; i < effects.Length; i++)
+        {
+            var col = i % cols;
+            var row = i / cols;
+            var x   = marginX + col * (dispSize + marginX);
+            var y   = marginY + row * rowH;
+
+            var sprite = new Sprite(_texture)
+            {
+                Material = effects[i].Mat
+            };
+            sprite.Location(x, y).Scale(scale, scale);
+
+            var label = new Text(effects[i].Label, font, Color.White)
+                .Location(x, y + dispSize + 4);
+
+            Root.AddRange(sprite, label);
+        }
+    }
+
+    public override void OnUpdate()
+    {
+        // ラスタースクロールのアニメーション時間を更新
+        _rasterScrollMat["uTime"] = (float)Window.TotalTime;
+
+        if (keyboard.Escape.IsKeyUp)
+            App.LoadScene<MainScene>();
+    }
+
+    public override void OnDestroy()
+    {
+        _texture.Dispose();
+        _sepiaShader.Dispose();
+        _grayscaleShader.Dispose();
+        _mosaicShader.Dispose();
+        _outlineShader.Dispose();
+        _rasterScrollShader.Dispose();
+    }
+}

--- a/Promete/GLDesktop/OpenGLDesktopAppExtension.cs
+++ b/Promete/GLDesktop/OpenGLDesktopAppExtension.cs
@@ -20,6 +20,7 @@ public static class OpenGLDesktopAppExtension
     public static PrometeApp BuildWithOpenGLDesktop(this PrometeApp.PrometeAppBuilder builder)
     {
         var app = builder
+            .Use<IShaderFactory, GLShaderFactory>()
             .Use<IFrameBufferProvider, GLFrameBufferProvider>()
             .Use<GLMaskedContainerHelper>()
             .Use<GLRenderState>()

--- a/Promete/Graphics/IShaderFactory.cs
+++ b/Promete/Graphics/IShaderFactory.cs
@@ -1,0 +1,14 @@
+namespace Promete.Graphics;
+
+/// <summary>
+/// シェーダープログラムのコンパイルを担うファクトリーのインターフェースです。
+/// バックエンドがこのインターフェースを実装し、DI コンテナに登録します。
+/// </summary>
+public interface IShaderFactory
+{
+    /// <summary>
+    /// <paramref name="program"/> のソースコードをコンパイルし、
+    /// <see cref="ShaderProgram.SetCompiledData"/> でハンドルと破棄デリゲートを設定します。
+    /// </summary>
+    void Compile(ShaderProgram program);
+}

--- a/Promete/Graphics/ShaderProgram.cs
+++ b/Promete/Graphics/ShaderProgram.cs
@@ -1,0 +1,67 @@
+using System;
+
+namespace Promete.Graphics;
+
+/// <summary>
+/// カスタムシェーダープログラムを表します。
+/// <see cref="Create"/> でビルダーを生成し、<see cref="Vertex"/>・<see cref="Fragment"/> で
+/// ソースコードを設定した後、<see cref="Compile"/> でコンパイルしてください。
+/// </summary>
+/// <remarks>
+/// <see cref="Compile"/> はメインスレッド上かつ GL コンテキストが有効な状態
+/// （<c>OnStart()</c> 以降）で呼び出してください。
+/// </remarks>
+public sealed class ShaderProgram : IDisposable
+{
+    /// <summary>頂点シェーダーのソースコードを取得します。</summary>
+    public string? VertexShaderSource { get; private set; }
+
+    /// <summary>フラグメントシェーダーのソースコードを取得します。</summary>
+    public string? FragmentShaderSource { get; private set; }
+
+    /// <summary>コンパイル済みシェーダープログラムのバックエンドハンドルを取得します。</summary>
+    public int Handle { get; private set; }
+
+    private Action<ShaderProgram>? _onDispose;
+
+    private ShaderProgram() { }
+
+    /// <summary>新しい <see cref="ShaderProgram"/> ビルダーを生成します。</summary>
+    public static ShaderProgram Create() => new();
+
+    /// <summary>頂点シェーダーのソースコードを設定します。</summary>
+    public ShaderProgram Vertex(string source)
+    {
+        VertexShaderSource = source;
+        return this;
+    }
+
+    /// <summary>フラグメントシェーダーのソースコードを設定します。</summary>
+    public ShaderProgram Fragment(string source)
+    {
+        FragmentShaderSource = source;
+        return this;
+    }
+
+    /// <summary>
+    /// シェーダーをコンパイルします。
+    /// 内部で <see cref="IShaderFactory"/> を取得し、バックエンドに処理を委譲します。
+    /// </summary>
+    public ShaderProgram Compile()
+    {
+        PrometeApp.Current.GetPlugin<IShaderFactory>().Compile(this);
+        return this;
+    }
+
+    /// <summary>
+    /// コンパイル済みデータを設定します。<see cref="IShaderFactory"/> の実装のみが呼び出します。
+    /// </summary>
+    internal void SetCompiledData(int handle, Action<ShaderProgram> onDispose)
+    {
+        Handle = handle;
+        _onDispose = onDispose;
+    }
+
+    /// <summary>GPU リソースを解放します。</summary>
+    public void Dispose() => _onDispose?.Invoke(this);
+}

--- a/Promete/Nodes/Material.cs
+++ b/Promete/Nodes/Material.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Collections.Generic;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+using Promete.Graphics;
+
+namespace Promete.Nodes;
+
+/// <summary>
+/// シェーダーと Uniform パラメーターをまとめたマテリアルを表します。
+/// <see cref="Node.Material"/> に設定することで、そのノードにカスタムシェーダーを適用できます。
+/// </summary>
+public sealed class Material : IEquatable<Material>
+{
+    /// <summary>このマテリアルが使用するシェーダープログラムを取得します。</summary>
+    public ShaderProgram Shader { get; }
+
+    private readonly Dictionary<string, object> _uniforms = new();
+
+    /// <summary>Uniform 値の読み取り専用ビュー（バックエンドのランナーが使用）。</summary>
+    internal IReadOnlyDictionary<string, object> Uniforms => _uniforms;
+
+    /// <param name="shader">使用するシェーダープログラム。</param>
+    public Material(ShaderProgram shader)
+    {
+        Shader = shader;
+    }
+
+    public object this[string key]
+    {
+        get => _uniforms[key];
+        set => _uniforms[key] = value;
+    }
+
+    /// <inheritdoc/>
+    public bool Equals(Material? other)
+    {
+        if (other is null) return false;
+        if (ReferenceEquals(this, other)) return true;
+        if (!ReferenceEquals(Shader, other.Shader)) return false;
+        if (_uniforms.Count != other._uniforms.Count) return false;
+        foreach (var (k, v) in _uniforms)
+        {
+            if (!other._uniforms.TryGetValue(k, out var ov)) return false;
+            if (!v.Equals(ov)) return false;
+        }
+        return true;
+    }
+
+    /// <inheritdoc/>
+    public override bool Equals(object? obj) => obj is Material m && Equals(m);
+
+    /// <inheritdoc/>
+    public override int GetHashCode()
+    {
+        // Shader は参照ハッシュ、Uniform は XOR で順序非依存
+        var h = RuntimeHelpers.GetHashCode(Shader);
+        foreach (var (k, v) in _uniforms)
+            h ^= HashCode.Combine(k, v);
+        return h;
+    }
+}

--- a/Promete/Nodes/NineSliceSprite.cs
+++ b/Promete/Nodes/NineSliceSprite.cs
@@ -40,6 +40,7 @@ public class NineSliceSprite(Texture9Sliced texture, Color? tintColor = default)
                 Width = width ?? tex.Size.X,
                 Height = height ?? tex.Size.Y,
                 Pivot = pivot,
+                Material = Material,
             });
         }
 

--- a/Promete/Nodes/Node.cs
+++ b/Promete/Nodes/Node.cs
@@ -86,6 +86,12 @@ public abstract class Node
     public bool IsDestroyed { get; private set; }
 
     /// <summary>
+    /// このノードに適用するマテリアルを取得または設定します。使用されない場合もあります。
+    /// null の場合はデフォルトシェーダーで描画します。
+    /// </summary>
+    public Material? Material { get; set; }
+
+    /// <summary>
     /// このノードの幅を取得または設定します。
     /// </summary>
     public int Width

--- a/Promete/Nodes/PieSprite.cs
+++ b/Promete/Nodes/PieSprite.cs
@@ -47,6 +47,7 @@ public class PieSprite(Texture2D? texture = null, Color? tintColor = default) : 
             Height = Size.Y,
             StartPercent = StartPercent,
             Percent = Percent,
+            Material = Material,
         });
     }
 }

--- a/Promete/Nodes/Renderer/Commands/DrawPieTextureCommand.cs
+++ b/Promete/Nodes/Renderer/Commands/DrawPieTextureCommand.cs
@@ -1,6 +1,7 @@
 using System.Drawing;
 using System.Numerics;
 using Promete.Graphics;
+using Promete.Nodes;
 
 namespace Promete.Nodes.Renderer.Commands;
 
@@ -16,4 +17,7 @@ public sealed class DrawPieTextureCommand : IRenderCommand
     public required float Height { get; init; }
     public required float StartPercent { get; init; }
     public required float Percent { get; init; }
+
+    /// <summary>適用するマテリアル。null の場合はデフォルトシェーダーを使用します。</summary>
+    public Material? Material { get; init; }
 }

--- a/Promete/Nodes/Renderer/Commands/DrawPrimitiveCommand.cs
+++ b/Promete/Nodes/Renderer/Commands/DrawPrimitiveCommand.cs
@@ -1,4 +1,5 @@
 using System.Drawing;
+using Promete.Nodes;
 
 namespace Promete.Nodes.Renderer.Commands;
 
@@ -12,4 +13,7 @@ public sealed class DrawPrimitiveCommand : IRenderCommand
     public required Color Color { get; init; }
     public int LineWidth { get; init; }
     public Color? LineColor { get; init; }
+
+    /// <summary>適用するマテリアル。null の場合はデフォルトシェーダーを使用します。</summary>
+    public Material? Material { get; init; }
 }

--- a/Promete/Nodes/Renderer/Commands/DrawTextureBatchedCommand.cs
+++ b/Promete/Nodes/Renderer/Commands/DrawTextureBatchedCommand.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using Promete.Graphics;
+using Promete.Nodes;
 
 namespace Promete.Nodes.Renderer.Commands;
 
@@ -13,12 +14,16 @@ internal sealed class DrawTextureBatchedCommand : IRenderCommand
     /// <summary>バッチ内の全アイテムで共通のテクスチャ。</summary>
     public Texture2D Texture { get; private set; }
 
+    /// <summary>バッチ内の全アイテムで共通のマテリアル。null の場合はデフォルトシェーダー。</summary>
+    public Material? Material { get; private set; }
+
     /// <summary>バッチ内の個別描画アイテム。</summary>
     public List<DrawTextureCommand> Items { get; } = new(512);
 
     internal void Reset(DrawTextureCommand first)
     {
         Texture = first.Texture;
+        Material = first.Material;
         Items.Clear();
         Items.Add(first);
     }

--- a/Promete/Nodes/Renderer/Commands/DrawTextureCommand.cs
+++ b/Promete/Nodes/Renderer/Commands/DrawTextureCommand.cs
@@ -1,6 +1,7 @@
 using System.Drawing;
 using System.Numerics;
 using Promete.Graphics;
+using Promete.Nodes;
 
 namespace Promete.Nodes.Renderer.Commands;
 
@@ -17,6 +18,9 @@ public readonly struct DrawTextureCommand : IRenderCommand
 
     /// <summary>描画オフセット（ローカル座標）。デフォルトは原点。</summary>
     public Vector Pivot { get; init; }
+
+    /// <summary>適用するマテリアル。null の場合はデフォルトシェーダーを使用します。</summary>
+    public Material? Material { get; init; }
 
     public DrawTextureCommand()
     {

--- a/Promete/Nodes/Renderer/GL/GLShaderFactory.cs
+++ b/Promete/Nodes/Renderer/GL/GLShaderFactory.cs
@@ -1,0 +1,74 @@
+using System;
+using Promete.Graphics;
+using Promete.Nodes.Renderer.GL.Helper;
+using Promete.Windowing;
+using Promete.Windowing.GLDesktop;
+using Silk.NET.OpenGL;
+
+namespace Promete.Nodes.Renderer.GL;
+
+/// <summary>
+/// OpenGL バックエンドにおける <see cref="IShaderFactory"/> の実装です。
+/// </summary>
+internal class GLShaderFactory(IWindow window) : IShaderFactory
+{
+    private readonly OpenGLDesktopWindow _window = window as OpenGLDesktopWindow
+        ?? throw new InvalidOperationException("Window is not an OpenGLDesktopWindow");
+
+    /// <inheritdoc/>
+    public void Compile(ShaderProgram program)
+    {
+        PrometeApp.Current.ThrowIfNotMainThread();
+        var gl = _window.GL;
+
+        var vSrc = program.VertexShaderSource
+            ?? throw new InvalidOperationException("頂点シェーダーのソースコードが設定されていません。");
+        var fSrc = program.FragmentShaderSource
+            ?? throw new InvalidOperationException("フラグメントシェーダーのソースコードが設定されていません。");
+
+        var vsh = gl.CreateShader(ShaderType.VertexShader);
+        gl.ShaderSource(vsh, vSrc);
+        gl.CompileShader(vsh);
+        CheckShaderCompile(gl, vsh, "vertex");
+
+        var fsh = gl.CreateShader(ShaderType.FragmentShader);
+        gl.ShaderSource(fsh, fSrc);
+        gl.CompileShader(fsh);
+        CheckShaderCompile(gl, fsh, "fragment");
+
+        var prog = gl.CreateProgram();
+        gl.AttachShader(prog, vsh);
+        gl.AttachShader(prog, fsh);
+        gl.LinkProgram(prog);
+        CheckProgramLink(gl, prog);
+
+        gl.DetachShader(prog, vsh);
+        gl.DetachShader(prog, fsh);
+        gl.DeleteShader(vsh);
+        gl.DeleteShader(fsh);
+
+        program.SetCompiledData((int)prog, OnDispose);
+    }
+
+    private static void CheckShaderCompile(Silk.NET.OpenGL.GL gl, uint shader, string stage)
+    {
+        gl.GetShader(shader, ShaderParameterName.CompileStatus, out var status);
+        if (status != 0) return;
+        var log = gl.GetShaderInfoLog(shader);
+        throw new InvalidOperationException($"シェーダーのコンパイルエラー ({stage}): {log}");
+    }
+
+    private static void CheckProgramLink(Silk.NET.OpenGL.GL gl, uint program)
+    {
+        gl.GetProgram(program, ProgramPropertyARB.LinkStatus, out var status);
+        if (status != 0) return;
+        var log = gl.GetProgramInfoLog(program);
+        throw new InvalidOperationException($"シェーダーのリンクエラー: {log}");
+    }
+
+    private void OnDispose(ShaderProgram p)
+    {
+        _window.GL.DeleteProgram((uint)p.Handle);
+        GLMaterialApplier.InvalidateProgram(p.Handle);
+    }
+}

--- a/Promete/Nodes/Renderer/GL/Helper/GLMaterialApplier.cs
+++ b/Promete/Nodes/Renderer/GL/Helper/GLMaterialApplier.cs
@@ -1,0 +1,92 @@
+using System.Collections.Generic;
+using System.Numerics;
+using Promete.Graphics;
+using Silk.NET.OpenGL;
+
+namespace Promete.Nodes.Renderer.GL.Helper;
+
+/// <summary>
+/// マテリアルの Uniform 値を OpenGL プログラムに適用するヘルパーです。
+/// Uniform ロケーションをプログラムハンドルと名前のペアでキャッシュし、
+/// フレームごとの <c>glGetUniformLocation</c> 呼び出しを最小化します。
+/// </summary>
+internal static class GLMaterialApplier
+{
+    private static readonly Dictionary<(int programHandle, string name), int> _locationCache = new();
+
+    /// <summary>
+    /// Uniform のロケーションをキャッシュ付きで取得します。
+    /// 初回のみ <c>glGetUniformLocation</c> を呼び出し、以降はキャッシュから返します。
+    /// </summary>
+    public static int GetLocation(Silk.NET.OpenGL.GL gl, uint program, string name)
+    {
+        var key = ((int)program, name);
+        if (!_locationCache.TryGetValue(key, out var loc))
+        {
+            loc = gl.GetUniformLocation(program, name);
+            _locationCache[key] = loc;
+        }
+        return loc;
+    }
+
+    /// <summary>
+    /// マテリアルのカスタム Uniform 値を GL プログラムに適用します。
+    /// </summary>
+    /// <param name="gl">GL コンテキスト。</param>
+    /// <param name="program">適用先の GL プログラムハンドル。</param>
+    /// <param name="material">適用するマテリアル。</param>
+    /// <param name="firstTextureSlot">
+    /// Texture2D Uniform に使用を開始するテクスチャスロット番号。
+    /// スロット 0 はメインテクスチャ（<c>uTexture0</c>）用に予約されているため、デフォルトは 1 です。
+    /// </param>
+    public static unsafe void Apply(Silk.NET.OpenGL.GL gl, uint program, Material material, int firstTextureSlot = 1)
+    {
+        var textureSlot = firstTextureSlot;
+        foreach (var (name, value) in material.Uniforms)
+        {
+            var loc = GetLocation(gl, program, name);
+            if (loc < 0) continue;
+            switch (value)
+            {
+                case float f:
+                    gl.Uniform1(loc, f);
+                    break;
+                case int i:
+                    gl.Uniform1(loc, i);
+                    break;
+                case Vector2 v2:
+                    gl.Uniform2(loc, v2.X, v2.Y);
+                    break;
+                case Vector3 v3:
+                    gl.Uniform3(loc, v3.X, v3.Y, v3.Z);
+                    break;
+                case Vector4 v4:
+                    gl.Uniform4(loc, v4.X, v4.Y, v4.Z, v4.W);
+                    break;
+                case Matrix4x4 m:
+                    gl.UniformMatrix4(loc, 1, false, (float*)&m);
+                    break;
+                case Texture2D t:
+                    gl.ActiveTexture(TextureUnit.Texture0 + textureSlot);
+                    gl.BindTexture(TextureTarget.Texture2D, (uint)t.Handle);
+                    gl.Uniform1(loc, textureSlot);
+                    textureSlot++;
+                    break;
+            }
+        }
+    }
+
+    /// <summary>
+    /// 指定したプログラムハンドルに関連するキャッシュエントリをすべて削除します。
+    /// <see cref="Graphics.ShaderProgram.Dispose"/> 時に呼び出してください。
+    /// </summary>
+    internal static void InvalidateProgram(int programHandle)
+    {
+        var keysToRemove = new List<(int programHandle, string name)>();
+        foreach (var key in _locationCache.Keys)
+            if (key.programHandle == programHandle)
+                keysToRemove.Add(key);
+        foreach (var key in keysToRemove)
+            _locationCache.Remove(key);
+    }
+}

--- a/Promete/Nodes/Renderer/GL/Runners/GLDrawPieTextureCommandRunner.cs
+++ b/Promete/Nodes/Renderer/GL/Runners/GLDrawPieTextureCommandRunner.cs
@@ -25,7 +25,7 @@ public class GLDrawPieTextureCommandRunner(IWindow window) : CommandRunner<DrawP
 
     public override void Execute(DrawPieTextureCommand command)
     {
-        Draw(command.Texture, command.ModelMatrix, command.TintColor, command.Width, command.Height, command.StartPercent, command.Percent);
+        Draw(command.Texture, command.ModelMatrix, command.TintColor, command.Width, command.Height, command.StartPercent, command.Percent, command.Material);
     }
 
     /// <summary>
@@ -38,7 +38,8 @@ public class GLDrawPieTextureCommandRunner(IWindow window) : CommandRunner<DrawP
     /// <param name="height">描画高さ。</param>
     /// <param name="startPercent">描画開始位置のパーセント（0.0 ~ 100.0）。</param>
     /// <param name="percent">描画終了位置のパーセント（0.0 ~ 100.0）。</param>
-    public unsafe void Draw(Texture2D texture, Matrix4x4 modelMatrix, Color color, float width, float height, float startPercent, float percent)
+    /// <param name="material">適用するマテリアル。null の場合はデフォルトシェーダーを使用します。</param>
+    public unsafe void Draw(Texture2D texture, Matrix4x4 modelMatrix, Color color, float width, float height, float startPercent, float percent, Material? material = null)
     {
         PrometeApp.Current.ThrowIfNotMainThread();
         EnsureInitialized();
@@ -75,20 +76,40 @@ public class GLDrawPieTextureCommandRunner(IWindow window) : CommandRunner<DrawP
             BlendingFactor.One, BlendingFactor.OneMinusSrcAlpha // Alpha
         );
 
-        // シェーダーおよびテクスチャを利用する
-        gl.UseProgram(_shader);
+        // シェーダー選択: カスタムマテリアルがある場合はそのプログラムを使用
+        var program = material is { } mat ? (uint)mat.Shader.Handle : _shader;
+        gl.UseProgram(program);
+
         gl.ActiveTexture(TextureUnit.Texture0);
         gl.BindTexture(TextureTarget.Texture2D, (uint)texture.Handle);
 
-        // シェーダーに行列情報を渡す
-        gl.UniformMatrix4(_uModel, 1, false, (float*)&modelMatrix);
-        gl.UniformMatrix4(_uProjection, 1, false, (float*)&projectionMatrix);
-        gl.Uniform1(_uTexture0, 0);
-        gl.Uniform4(_uTintColor, new Vector4(c.R / 255f, c.G / 255f, c.B / 255f, c.A / 255f));
-
-        // パーセント角度をシェーダーに渡す
-        gl.Uniform1(_uStartAngle, startAngle);
-        gl.Uniform1(_uEndAngle, endAngle);
+        if (material is not null)
+        {
+            // カスタムシェーダー: ロケーションをキャッシュ付きで取得 (-1 はスキップ)
+            var uModel = GLMaterialApplier.GetLocation(gl, program, "uModel");
+            var uProj = GLMaterialApplier.GetLocation(gl, program, "uProjection");
+            var uTex = GLMaterialApplier.GetLocation(gl, program, "uTexture0");
+            var uTint = GLMaterialApplier.GetLocation(gl, program, "uTintColor");
+            var uStart = GLMaterialApplier.GetLocation(gl, program, "uStartAngle");
+            var uEnd = GLMaterialApplier.GetLocation(gl, program, "uEndAngle");
+            if (uModel >= 0) gl.UniformMatrix4(uModel, 1, false, (float*)&modelMatrix);
+            if (uProj >= 0) gl.UniformMatrix4(uProj, 1, false, (float*)&projectionMatrix);
+            if (uTex >= 0) gl.Uniform1(uTex, 0);
+            if (uTint >= 0) gl.Uniform4(uTint, new Vector4(c.R / 255f, c.G / 255f, c.B / 255f, c.A / 255f));
+            if (uStart >= 0) gl.Uniform1(uStart, startAngle);
+            if (uEnd >= 0) gl.Uniform1(uEnd, endAngle);
+            GLMaterialApplier.Apply(gl, program, material);
+        }
+        else
+        {
+            // デフォルトシェーダー: キャッシュ済みロケーションを使用
+            gl.UniformMatrix4(_uModel, 1, false, (float*)&modelMatrix);
+            gl.UniformMatrix4(_uProjection, 1, false, (float*)&projectionMatrix);
+            gl.Uniform1(_uTexture0, 0);
+            gl.Uniform4(_uTintColor, new Vector4(c.R / 255f, c.G / 255f, c.B / 255f, c.A / 255f));
+            gl.Uniform1(_uStartAngle, startAngle);
+            gl.Uniform1(_uEndAngle, endAngle);
+        }
 
         // 描画
         gl.BindVertexArray(_vao);

--- a/Promete/Nodes/Renderer/GL/Runners/GLDrawPrimitiveCommandRunner.cs
+++ b/Promete/Nodes/Renderer/GL/Runners/GLDrawPrimitiveCommandRunner.cs
@@ -25,7 +25,7 @@ public class GLDrawPrimitiveCommandRunner(IWindow window) : CommandRunner<DrawPr
 
     public override void Execute(DrawPrimitiveCommand command)
     {
-        Draw(command.WorldVertices, command.ShapeType, command.Color, command.LineWidth, command.LineColor);
+        Draw(command.WorldVertices, command.ShapeType, command.Color, command.LineWidth, command.LineColor, command.Material);
     }
 
     /// <summary>
@@ -36,8 +36,9 @@ public class GLDrawPrimitiveCommandRunner(IWindow window) : CommandRunner<DrawPr
     /// <param name="color">図形の塗りつぶし色</param>
     /// <param name="lineWidth">線の幅。GPUによってはサポートされません。</param>
     /// <param name="lineColor">線の色。</param>
+    /// <param name="material">適用するマテリアル。null の場合はデフォルトシェーダーを使用します。</param>
     public unsafe void Draw(Span<Vector> worldVertices, ShapeType type, Color color, int lineWidth = 0,
-        Color? lineColor = null)
+        Color? lineColor = null, Material? material = null)
     {
         PrometeApp.Current.ThrowIfNotMainThread();
         if (worldVertices.Length == 0)
@@ -67,6 +68,9 @@ public class GLDrawPrimitiveCommandRunner(IWindow window) : CommandRunner<DrawPr
             vertices[i * 2 + 1] = y;
         }
 
+        // シェーダー選択: カスタムマテリアルがある場合はそのプログラムを使用
+        var program = material is { } mat ? (uint)mat.Shader.Handle : _shader;
+
         // 描画開始
         gl.Enable(GLEnum.Blend);
         gl.BlendFuncSeparate(
@@ -74,8 +78,8 @@ public class GLDrawPrimitiveCommandRunner(IWindow window) : CommandRunner<DrawPr
             BlendingFactor.One, BlendingFactor.OneMinusSrcAlpha // Alpha
         );
 
-        DrawFill(vertices, type, color, lineWidth);
-        DrawStroke(vertices, lineWidth, lineColor);
+        DrawFill(vertices, type, color, lineWidth, program, material);
+        DrawStroke(vertices, lineWidth, lineColor, program, material);
 
         gl.Disable(EnableCap.Blend);
     }
@@ -83,7 +87,7 @@ public class GLDrawPrimitiveCommandRunner(IWindow window) : CommandRunner<DrawPr
     /// <summary>
     /// 図形の線を描画します。
     /// </summary>
-    private unsafe void DrawStroke(Span<float> vertices, int lineWidth, Color? lineColor)
+    private unsafe void DrawStroke(Span<float> vertices, int lineWidth, Color? lineColor, uint program, Material? material)
     {
         if (lineWidth <= 0 || lineColor is not { } lc) return;
         var gl = _window.GL;
@@ -96,14 +100,19 @@ public class GLDrawPrimitiveCommandRunner(IWindow window) : CommandRunner<DrawPr
         gl.BufferData<float>(GLEnum.ArrayBuffer, vertices, GLEnum.StaticDraw);
 
         // シェーダーを利用する
-        gl.UseProgram(_shader);
+        gl.UseProgram(program);
 
         // 頂点属性を設定
         gl.VertexAttribPointer(0, 2, GLEnum.Float, false, 2 * sizeof(float), (void*)(0 * sizeof(float)));
         gl.EnableVertexAttribArray(0);
 
         // シェーダーに線の色を渡す
-        gl.Uniform4(_uTintColor, new Vector4(lc.R / 255f, lc.G / 255f, lc.B / 255f, lc.A / 255f));
+        var tintLoc = material is not null ? GLMaterialApplier.GetLocation(gl, program, "uTintColor") : _uTintColor;
+        if (tintLoc >= 0)
+            gl.Uniform4(tintLoc, new Vector4(lc.R / 255f, lc.G / 255f, lc.B / 255f, lc.A / 255f));
+
+        if (material is not null)
+            GLMaterialApplier.Apply(gl, program, material);
 
         // 描画
         gl.DrawArrays(PrimitiveType.LineLoop, 0, (uint)vertices.Length / 2);
@@ -112,7 +121,7 @@ public class GLDrawPrimitiveCommandRunner(IWindow window) : CommandRunner<DrawPr
     /// <summary>
     /// 図形の塗りつぶし領域を描画します。
     /// </summary>
-    private unsafe void DrawFill(Span<float> vertices, ShapeType type, Color color, int lineWidth)
+    private unsafe void DrawFill(Span<float> vertices, ShapeType type, Color color, int lineWidth, uint program, Material? material)
     {
         // 透明度が0未満の場合は、塗りつぶし領域の描画をスキップする
         if (color.A <= 0) return;
@@ -126,14 +135,19 @@ public class GLDrawPrimitiveCommandRunner(IWindow window) : CommandRunner<DrawPr
         gl.BufferData<float>(GLEnum.ArrayBuffer, vertices, GLEnum.StaticDraw);
 
         // シェーダーを利用する
-        gl.UseProgram(_shader);
+        gl.UseProgram(program);
 
         // 頂点属性を設定
         gl.VertexAttribPointer(0, 2, GLEnum.Float, false, 2 * sizeof(float), (void*)(0 * sizeof(float)));
         gl.EnableVertexAttribArray(0);
 
         // シェーダーに色データを渡す
-        gl.Uniform4(_uTintColor, new Vector4(color.R / 255f, color.G / 255f, color.B / 255f, color.A / 255f));
+        var tintLoc = material is not null ? GLMaterialApplier.GetLocation(gl, program, "uTintColor") : _uTintColor;
+        if (tintLoc >= 0)
+            gl.Uniform4(tintLoc, new Vector4(color.R / 255f, color.G / 255f, color.B / 255f, color.A / 255f));
+
+        if (material is not null)
+            GLMaterialApplier.Apply(gl, program, material);
 
         // 矩形の場合は、インデックスバッファを利用してドローコールを減らす
         // TODO: 他のタイプに対してもEBOを利用したい

--- a/Promete/Nodes/Renderer/GL/Runners/GLDrawTextureBatchedCommandRunner.cs
+++ b/Promete/Nodes/Renderer/GL/Runners/GLDrawTextureBatchedCommandRunner.cs
@@ -2,6 +2,8 @@
 using System;
 using System.Collections.Generic;
 using System.Numerics;
+using Promete.Graphics;
+using Promete.Nodes;
 using Promete.Nodes.Renderer.Commands;
 using Promete.Nodes.Renderer.GL.Helper;
 using Promete.Windowing;
@@ -42,13 +44,14 @@ internal class GLDrawTextureBatchedCommandRunner(IWindow window) : CommandRunner
 
     public override void Execute(DrawTextureBatchedCommand command)
     {
-        DrawInstanced(command.Items);
+        DrawInstanced(command.Items, command.Material);
     }
 
     /// <summary>
     /// バッチをインスタンシングで描画します。件数が1の場合もこちらを使用します。
+    /// <paramref name="material"/> が非 null の場合はそのシェーダーを使用し、カスタム Uniform を適用します。
     /// </summary>
-    private unsafe void DrawInstanced(List<DrawTextureCommand> items)
+    private unsafe void DrawInstanced(List<DrawTextureCommand> items, Material? material)
     {
         if (items.Count == 0) return;
         PrometeApp.Current.ThrowIfNotMainThread();
@@ -120,12 +123,28 @@ internal class GLDrawTextureBatchedCommandRunner(IWindow window) : CommandRunner
             BlendingFactor.SrcAlpha, BlendingFactor.OneMinusSrcAlpha,
             BlendingFactor.One, BlendingFactor.OneMinusSrcAlpha);
 
-        gl.UseProgram(_shader);
+        // シェーダー選択: カスタムマテリアルがある場合はそのプログラムを使用
+        var program = material is { } mat ? (uint)mat.Shader.Handle : _shader;
+        gl.UseProgram(program);
+
         gl.ActiveTexture(TextureUnit.Texture0);
         gl.BindTexture(TextureTarget.Texture2D, (uint)items[0].Texture.Handle);
 
-        gl.UniformMatrix4(_uProjection, 1, false, (float*)&projection);
-        gl.Uniform1(_uTexture0, 0);
+        if (material is not null)
+        {
+            // カスタムシェーダー: ロケーションをキャッシュ付きで取得 (-1 はスキップ)
+            var uProj = GLMaterialApplier.GetLocation(gl, program, "uProjection");
+            var uTex = GLMaterialApplier.GetLocation(gl, program, "uTexture0");
+            if (uProj >= 0) gl.UniformMatrix4(uProj, 1, false, (float*)&projection);
+            if (uTex >= 0) gl.Uniform1(uTex, 0);
+            GLMaterialApplier.Apply(gl, program, material);
+        }
+        else
+        {
+            // デフォルトシェーダー: キャッシュ済みロケーションを使用
+            gl.UniformMatrix4(_uProjection, 1, false, (float*)&projection);
+            gl.Uniform1(_uTexture0, 0);
+        }
 
         gl.BindVertexArray(_vao);
         gl.BindBuffer(BufferTargetARB.ElementArrayBuffer, _ebo);

--- a/Promete/Nodes/Renderer/RenderCommandQueue.cs
+++ b/Promete/Nodes/Renderer/RenderCommandQueue.cs
@@ -45,12 +45,14 @@ public class RenderCommandQueue
 
     /// <summary>
     /// <see cref="DrawTextureCommand"/> をキューに追加します。ボックス化なしでバッチに集約されます。
+    /// 同一テクスチャかつ同一マテリアルの連続するコマンドは1つのバッチにまとめられます。
     /// </summary>
     public void Enqueue(DrawTextureCommand texCmd)
     {
         if (_commands.Count > 0
             && _commands[^1] is DrawTextureBatchedCommand batch
-            && batch.Texture.Handle == texCmd.Texture.Handle)
+            && batch.Texture.Handle == texCmd.Texture.Handle
+            && MaterialEquals(batch.Material, texCmd.Material))
         {
             batch.Add(texCmd);
             return;
@@ -59,6 +61,13 @@ public class RenderCommandQueue
         var newBatch = _batchPool.Count > 0 ? _batchPool.Pop() : new DrawTextureBatchedCommand();
         newBatch.Reset(texCmd);
         _commands.Add(newBatch);
+    }
+
+    private static bool MaterialEquals(Material? a, Material? b)
+    {
+        if (a is null && b is null) return true;
+        if (a is null || b is null) return false;
+        return a.Equals(b);
     }
 
     /// <summary>

--- a/Promete/Nodes/Shape.cs
+++ b/Promete/Nodes/Shape.cs
@@ -12,6 +12,7 @@ public class Shape : Node
 {
     private DrawPrimitiveCommand? _cachedCommand;
     private Matrix4x4 _cachedModelMatrix;
+    private Material? _cachedMaterial;
 
     private Shape(Color c, ShapeType type, int lineWidth, Color? lineColor, params VectorInt[] vertices)
     {
@@ -50,7 +51,7 @@ public class Shape : Node
 
     internal override void Collect(RenderCommandQueue queue, RenderContext ctx)
     {
-        if (_cachedCommand == null || ModelMatrix != _cachedModelMatrix)
+        if (_cachedCommand == null || ModelMatrix != _cachedModelMatrix || !ReferenceEquals(Material, _cachedMaterial))
         {
             var worldVertices = new Vector[Vertices.Length];
             for (var i = 0; i < Vertices.Length; i++)
@@ -63,8 +64,10 @@ public class Shape : Node
                 Color = Color,
                 LineWidth = LineWidth,
                 LineColor = LineColor,
+                Material = Material,
             };
             _cachedModelMatrix = ModelMatrix;
+            _cachedMaterial = Material;
         }
 
         queue.Enqueue(_cachedCommand);

--- a/Promete/Nodes/Sprite.cs
+++ b/Promete/Nodes/Sprite.cs
@@ -52,6 +52,7 @@ public class Sprite(Texture2D? texture = null, Color? tintColor = default) : Nod
             TintColor = TintColor,
             Width = Size.X,
             Height = Size.Y,
+            Material = Material,
         });
     }
 


### PR DESCRIPTION
## 概要
Promete でシェーダーをサポートするためのAPIを追加しました。

- カスタムシェーダーを扱う `ShaderProgram` クラスと、シェーダー＋Uniform をまとめた `Material` クラスを新規追加
- `Node.Material` プロパティを追加し、すべてのノードにカスタムマテリアルを適用できるように
- OpenGL バックエンドに `IShaderFactory` / `GLShaderFactory` / `GLMaterialApplier` を実装し、コンパイル・Uniform 適用を担当

## 追加したデモ (`/graphics/materialEffect.demo`)
`ichigo.png` に対し、6 種類のシェーダーでエフェクトの実演をするデモ

🤖 Generated with [Claude Code](https://claude.com/claude-code)