### PR TITLE
SceneWillChangeイベントに遷移種類情報を追加

### DIFF
--- a/Promete/ConsoleLayer.cs
+++ b/Promete/ConsoleLayer.cs
@@ -49,7 +49,7 @@ public class ConsoleLayer(PrometeApp app, IGameView view) : IInitializable
 
         app.GlobalForeground.Add(_text);
 
-        app.SceneWillChange += Clear;
+        app.SceneWillChange += _ => Clear();
         app.Update += () => { _text.Update(); };
         app.PostUpdate += UpdateConsole;
         view.Resize += () => { _maxLine = CalculateMaxLine(); };

--- a/Promete/Coroutines/CoroutineManager.cs
+++ b/Promete/Coroutines/CoroutineManager.cs
@@ -16,7 +16,7 @@ public class CoroutineManager
     public CoroutineManager(PrometeApp app)
     {
         app.Update += Update;
-        app.SceneWillChange += ClearAllNonKeepAliveCoroutines;
+        app.SceneWillChange += _ => ClearAllNonKeepAliveCoroutines();
     }
 
     /// <summary>

--- a/Promete/PrometeApp.cs
+++ b/Promete/PrometeApp.cs
@@ -233,9 +233,10 @@ public sealed class PrometeApp : IDisposable
     /// <exception cref="ArgumentException">指定したシーンが存在しない。</exception>
     public void LoadScene(Type typeScene)
     {
+        var previous = _currentScene;
         _currentScene?.OnDestroy();
         _currentScene = GetScene(typeScene);
-        SceneWillChange?.Invoke();
+        SceneWillChange?.Invoke(new SceneTransitionEventArgs(SceneTransitionType.Load, previous, _currentScene));
         _currentScene.OnStart();
     }
 
@@ -254,6 +255,7 @@ public sealed class PrometeApp : IDisposable
     /// <param name="typeScene">読み込むシーン。</param>
     public void PushScene(Type typeScene)
     {
+        var previous = _currentScene;
         if (_currentScene != null)
         {
             _sceneStack.Push(_currentScene);
@@ -261,7 +263,7 @@ public sealed class PrometeApp : IDisposable
         }
 
         _currentScene = GetScene(typeScene);
-        SceneWillChange?.Invoke();
+        SceneWillChange?.Invoke(new SceneTransitionEventArgs(SceneTransitionType.Push, previous, _currentScene));
         _currentScene.OnStart();
     }
 
@@ -273,9 +275,10 @@ public sealed class PrometeApp : IDisposable
     {
         if (_sceneStack.Count == 0) return false;
 
+        var previous = _currentScene;
         _currentScene?.OnDestroy();
         _currentScene = _sceneStack.Pop();
-        SceneWillChange?.Invoke();
+        SceneWillChange?.Invoke(new SceneTransitionEventArgs(SceneTransitionType.Pop, previous, _currentScene));
         _currentScene.OnResume();
         return true;
     }
@@ -514,7 +517,7 @@ public sealed class PrometeApp : IDisposable
     /// <summary>
     /// シーンが変更される直前に呼び出されるイベントです。
     /// </summary>
-    public event Action? SceneWillChange;
+    public event Action<SceneTransitionEventArgs>? SceneWillChange;
 
     /// <summary>
     /// シーンを使用せずにアプリケーションを実行する際に使用されるデフォルトの空のシーン。

--- a/Promete/SceneTransitionEventArgs.cs
+++ b/Promete/SceneTransitionEventArgs.cs
@@ -1,0 +1,13 @@
+namespace Promete;
+
+/// <summary>
+/// シーン遷移イベントの引数を表します。
+/// </summary>
+/// <param name="Type">遷移の種類。</param>
+/// <param name="Previous">遷移前のシーン。存在しない場合は <see langword="null" />。</param>
+/// <param name="Next">遷移後のシーン。存在しない場合は <see langword="null" />。</param>
+public record SceneTransitionEventArgs(
+	SceneTransitionType Type,
+	Scene? Previous,
+	Scene? Next
+);

--- a/Promete/SceneTransitionType.cs
+++ b/Promete/SceneTransitionType.cs
@@ -1,0 +1,22 @@
+namespace Promete;
+
+/// <summary>
+/// シーン遷移の種類を表します。
+/// </summary>
+public enum SceneTransitionType
+{
+	/// <summary>
+	/// 現在のシーンを破棄し、新しいシーンを読み込みます。
+	/// </summary>
+	Load,
+
+	/// <summary>
+	/// 現在のシーンをスタックに保存し、新しいシーンを読み込みます。
+	/// </summary>
+	Push,
+
+	/// <summary>
+	/// 現在のシーンを破棄し、スタックからシーンを復帰させます。
+	/// </summary>
+	Pop,
+}


### PR DESCRIPTION
## Summary
- `SceneTransitionType` enum（Load/Push/Pop）と `SceneTransitionEventArgs` record を追加
- `SceneWillChange` イベントのシグネチャを `Action` → `Action<SceneTransitionEventArgs>` に変更
- 既存の購読者（ConsoleLayer、CoroutineManager）を新シグネチャに対応

## Motivation
プラグインがシーン遷移の種類に応じて処理を分岐できるようにする。例えば、Push時はリソースを一時停止しPopで再開、Loadでは破棄して再生成、といった制御が可能になる。

## Breaking changes
- `SceneWillChange` のシグネチャが `Action` → `Action<SceneTransitionEventArgs>` に変更

## Test plan
- [x] ビルド成功確認
- [x] 既存テスト（今回の変更と無関係の1件を除き）パス確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)