### PR TITLE
fix(Tilemap): AutoモードのGetPreferredModeをタイル空間的広がり比較に修正

### DIFF
--- a/Promete/Nodes/Tilemap.cs
+++ b/Promete/Nodes/Tilemap.cs
@@ -15,6 +15,11 @@ public class Tilemap(
 {
     private readonly Dictionary<VectorInt, (ITile tile, Color? color)> _tiles = [];
 
+    private int _minTileX = int.MaxValue;
+    private int _maxTileX = int.MinValue;
+    private int _minTileY = int.MaxValue;
+    private int _maxTileY = int.MinValue;
+
     /// <summary>
     /// グリッドのサイズを取得または設定します。
     /// </summary>
@@ -65,14 +70,23 @@ public class Tilemap(
 
     private TilemapRenderingMode GetPreferredMode(RenderContext ctx)
     {
+        if (_tiles.Count == 0)
+            return TilemapRenderingMode.RenderAll;
+
+        // タイルマップの空間的広がり（タイル単位）
+        var mapW = _maxTileX - _minTileX + 1;
+        var mapH = _maxTileY - _minTileY + 1;
+
+        // ビューポートに収まるタイル数（ScanAndCollect と同じ計算式）
         var tileSize = TileSize * AbsoluteScale;
         var (ww, wh) = ctx.WindowSize;
         var maxTilesX = ww / tileSize.X + 2;
         var maxTilesY = wh / tileSize.Y + 2;
-        var maxTilesInWindow = maxTilesX * maxTilesY;
-        return maxTilesInWindow < Tiles.Count
-            ? TilemapRenderingMode.Scan
-            : TilemapRenderingMode.RenderAll;
+
+        // マップ全体がビューポートに収まる場合のみ RenderAll、それ以外は Scan
+        return (mapW <= maxTilesX && mapH <= maxTilesY)
+            ? TilemapRenderingMode.RenderAll
+            : TilemapRenderingMode.Scan;
     }
 
     private void ScanAndCollect(RenderCommandQueue queue, RenderContext ctx)
@@ -173,9 +187,19 @@ public class Tilemap(
     public void SetTile(VectorInt point, ITile? tile, Color? color = null)
     {
         if (tile == null)
+        {
             _tiles.Remove(point);
+            // バウンディングボックスの縮小は O(n) スキャンが必要なため省略。
+            // 保守的に大きめに保つことで Scan が過剰選択されることがあるが常に安全。
+        }
         else
+        {
             _tiles[point] = (tile, color ?? DefaultColor);
+            if (point.X < _minTileX) _minTileX = point.X;
+            if (point.X > _maxTileX) _maxTileX = point.X;
+            if (point.Y < _minTileY) _minTileY = point.Y;
+            if (point.Y > _maxTileY) _maxTileY = point.Y;
+        }
     }
 
     /// <summary>
@@ -192,6 +216,10 @@ public class Tilemap(
     public void Clear()
     {
         _tiles.Clear();
+        _minTileX = int.MaxValue;
+        _maxTileX = int.MinValue;
+        _minTileY = int.MaxValue;
+        _maxTileY = int.MinValue;
     }
 
     /// <summary>


### PR DESCRIPTION
## 概要

macOS (MacBook Air) で約2000タイルの Tilemap を表示すると、`RenderingMode.Auto`（デフォルト）のままでは著しくパフォーマンスが低下する問題を修正します。

## 原因

`GetPreferredMode()` のヒューリスティックが誤っていました。

**旧ロジック（バグあり）**:
```
ビューポートのタイル容量 < タイル総数 → Scan
それ以外 → RenderAll
```

タイル配置の**形状**を考慮しないため、例えば 200×10 配置の2000タイルに対して、1280×720 ウィンドウのビューポート容量（82×47 = 3854）が上回ると **RenderAll を誤選択**していました。実際には横幅が画面を超えており、約120列が画面外にあります。

## 修正内容

- タイル配置のバウンディングボックス（`_minTileX`, `_maxTileX`, `_minTileY`, `_maxTileY`）を `SetTile()` でインクリメンタルに追跡し、`Clear()` でリセット
- `GetPreferredMode()` をタイルマップの**列数・行数** vs ビューポートの**タイル収容数**の比較に変更

**新ロジック**:
```
mapW <= maxTilesX && mapH <= maxTilesY → RenderAll（マップ全体がビューポートに収まる）
それ以外 → Scan
```

これにより `Auto` のまま Scan が正しく選ばれ、macOS での60fps維持が期待できます。

## 備考

- HiDPI / PixelRatio は `ctx.WindowSize`（論理ピクセル）を使用しているため無関係であることを確認済み
- タイル削除時のバウンディングボックス縮小は O(n) コストが必要なため意図的に省略（保守的に大きめに保つことで Scan が過剰選択されることがあるが常に安全）
- 変更ファイルは `Promete/Nodes/Tilemap.cs` のみ